### PR TITLE
Audit fix 5: enforce exact ETH payments in mint functions

### DIFF
--- a/src/facets/EmblemVaultMintFacet.sol
+++ b/src/facets/EmblemVaultMintFacet.sol
@@ -324,17 +324,16 @@ contract EmblemVaultMintFacet {
     /// @param params MintParams struct containing minting parameters
     /// @return bool True if mint was successful
     function _mintRouter(MintParams memory params) private returns (bool) {
-        bool isERC1155 = LibInterfaceIds.isERC1155(params.nftAddress);
-        bool isERC721A = !isERC1155 && LibInterfaceIds.isERC721A(params.nftAddress);
-
-        if (isERC1155) {
+        if (LibInterfaceIds.isERC1155(params.nftAddress)) {
             IERC1155(params.nftAddress).mintWithSerial(
                 params.to, params.tokenId, params.amount, params.serialNumbers
             );
-        } else if (isERC721A) {
+            return true;
+        } else if (LibInterfaceIds.isERC721A(params.nftAddress)) {
             IERC721AVault(params.nftAddress).mint(params.to, params.tokenId);
+            return true;
         }
-        return true;
+        return false;
     }
 
     /// @notice Internal router function to handle batch minting based on token type
@@ -354,18 +353,17 @@ contract EmblemVaultMintFacet {
         uint256[][] memory serialNumbers,
         bytes memory data
     ) private returns (bool) {
-        bool isERC1155 = LibInterfaceIds.isERC1155(nftAddress);
-        bool isERC721A = !isERC1155 && LibInterfaceIds.isERC721A(nftAddress);
-
-        if (isERC1155) {
+        if (LibInterfaceIds.isERC1155(nftAddress)) {
             uint256 len = tokenIds.length;
             for (uint256 i = 0; i < len; i++) {
                 IERC1155(nftAddress).mintWithSerial(to, tokenIds[i], amounts[i], serialNumbers[i]);
             }
-        } else if (isERC721A) {
+            return true;
+        } else if (LibInterfaceIds.isERC721A(nftAddress)) {
             IERC721AVault(nftAddress).batchMintWithData(to, tokenIds, data);
+            return true;
         }
-        return true;
+        return false;
     }
 
     /// @notice Converts a uint256 to its string representation

--- a/src/facets/EmblemVaultMintFacet.sol
+++ b/src/facets/EmblemVaultMintFacet.sol
@@ -239,8 +239,8 @@ contract EmblemVaultMintFacet {
         }
 
         if (params.payment == address(0)) {
-            LibErrors.revertIfInsufficientETH(msg.value, totalPrice);
-            (bool success,) = vs.recipientAddress.call{value: msg.value}("");
+            LibErrors.revertIfIncorrectPayment(msg.value, totalPrice);
+            (bool success,) = vs.recipientAddress.call{value: totalPrice}("");
             if (!success) {
                 revert LibErrors.ETHTransferFailed();
             }
@@ -271,8 +271,8 @@ contract EmblemVaultMintFacet {
         LibEmblemVaultStorage.VaultStorage storage vs = LibEmblemVaultStorage.vaultStorage();
 
         if (params.payment == address(0)) {
-            LibErrors.revertIfInsufficientETH(msg.value, params.price);
-            (bool success,) = vs.recipientAddress.call{value: msg.value}("");
+            LibErrors.revertIfIncorrectPayment(msg.value, params.price);
+            (bool success,) = vs.recipientAddress.call{value: params.price}("");
             if (!success) {
                 revert LibErrors.ETHTransferFailed();
             }

--- a/src/facets/EmblemVaultMintFacet.sol
+++ b/src/facets/EmblemVaultMintFacet.sol
@@ -365,34 +365,4 @@ contract EmblemVaultMintFacet {
         }
         return false;
     }
-
-    /// @notice Converts a uint256 to its string representation
-    /// @dev Optimized version that avoids expensive string operations
-    /// @param value The uint256 value to convert
-    /// @return string memory The string representation of the value
-    function _uintToStrOptimized(uint256 value) internal pure returns (string memory) {
-        if (value == 0) {
-            return "0";
-        }
-
-        uint256 temp = value;
-        uint256 digits;
-        while (temp != 0) {
-            unchecked {
-                digits++;
-                temp /= 10;
-            }
-        }
-
-        bytes memory buffer = new bytes(digits);
-        while (value != 0) {
-            unchecked {
-                digits -= 1;
-                buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
-                value /= 10;
-            }
-        }
-
-        return string(buffer);
-    }
 }

--- a/src/facets/EmblemVaultUnvaultFacet.sol
+++ b/src/facets/EmblemVaultUnvaultFacet.sol
@@ -334,7 +334,11 @@ contract EmblemVaultUnvaultFacet {
     {
         if (LibInterfaceIds.isERC1155(_nftAddress)) {
             IIsSerialized serialized = IIsSerialized(_nftAddress);
-            serialNumber = serialized.getFirstSerialByOwner(msg.sender, tokenId);
+
+            // Get the last serial number (LIFO)
+            uint256 balance = IERC1155(_nftAddress).balanceOf(msg.sender, tokenId);
+            if (balance == 0) revert LibErrors.InvalidAmount(0);
+            serialNumber = serialized.getSerialByOwnerAtIndex(msg.sender, tokenId, balance - 1);
 
             if (serialized.getTokenIdForSerialNumber(serialNumber) != tokenId) {
                 revert LibErrors.InvalidTokenId(tokenId);

--- a/src/facets/EmblemVaultUnvaultFacet.sol
+++ b/src/facets/EmblemVaultUnvaultFacet.sol
@@ -333,8 +333,12 @@ contract EmblemVaultUnvaultFacet {
         returns (bool success, uint256 serialNumber, bytes memory data)
     {
         if (LibInterfaceIds.isERC1155(_nftAddress)) {
-            IIsSerialized serialized = IIsSerialized(_nftAddress);
+            // Verify serialization support before casting
+            LibErrors.revertIfInterfaceNotSupported(
+                _nftAddress, LibInterfaceIds.isSerialized(_nftAddress), "IIsSerialized"
+            );
 
+            IIsSerialized serialized = IIsSerialized(_nftAddress);
             // Get the last serial number (LIFO)
             uint256 balance = IERC1155(_nftAddress).balanceOf(msg.sender, tokenId);
             if (balance == 0) revert LibErrors.InvalidAmount(0);

--- a/src/facets/EmblemVaultUnvaultFacet.sol
+++ b/src/facets/EmblemVaultUnvaultFacet.sol
@@ -42,6 +42,13 @@ contract EmblemVaultUnvaultFacet {
     }
 
     // Events
+    /// @notice Emitted when a token is unvaulted
+    /// @param nftAddress The address of the NFT contract
+    /// @param tokenId The ID of the token unvaulted
+    /// @param unvaulter The address that performed the unvault
+    /// @param serialNumber For ERC1155: the serial number from serialization interface
+    ///                    For ERC721A: the internal token ID
+    /// @param data Additional data from the unvault operation
     event TokenUnvaulted(
         address indexed nftAddress,
         uint256 indexed tokenId,
@@ -49,6 +56,15 @@ contract EmblemVaultUnvaultFacet {
         uint256 serialNumber,
         bytes data
     );
+
+    /// @notice Emitted when a token is unvaulted with a price
+    /// @param nftAddress The address of the NFT contract
+    /// @param tokenId The ID of the token unvaulted
+    /// @param unvaulter The address that performed the unvault
+    /// @param price The price paid for the unvault
+    /// @param serialNumber For ERC1155: the serial number from serialization interface
+    ///                    For ERC721A: the internal token ID
+    /// @param data Additional data from the unvault operation
     event TokenUnvaultedWithPrice(
         address indexed nftAddress,
         uint256 indexed tokenId,
@@ -100,7 +116,7 @@ contract EmblemVaultUnvaultFacet {
     }
 
     /// @notice Unvaults a token from a vault
-    /// @dev Handles the unvaulting process for both ERC721 and ERC1155 tokens
+    /// @dev Handles the unvaulting process for both ERC721A and ERC1155 tokens
     /// @param _nftAddress The address of the NFT contract
     /// @param tokenId The ID of the token to unvault
     /// @dev Reverts if:
@@ -317,17 +333,22 @@ contract EmblemVaultUnvaultFacet {
     }
 
     /// @notice Internal function to handle the burn and unvault process
-    /// @dev Routes the burn operation based on token standard (ERC721/ERC1155)
+    /// @dev Routes the burn operation based on token standard (ERC721A/ERC1155)
     /// @param _nftAddress The address of the NFT contract
     /// @param tokenId The ID of the token to burn
     /// @param shouldUnvault Whether to trigger the unvault process
     /// @return success Whether the burn was successful
-    /// @return serialNumber The serial number of the burned token
+    /// @return serialNumber For ERC1155: the serial number from serialization interface
+    ///                     For ERC721A: the internal token ID
     /// @return data Additional data from the burn operation
     /// @dev Reverts if:
     /// - The unvaulter contract is not set
     /// - The token is already unvaulted
     /// - The vault doesn't own the token
+    /// @dev Note on serialNumber: The meaning of serialNumber in events differs by token type:
+    ///      - For ERC1155: Uses the serial number from the serialization interface
+    ///      - For ERC721A: Uses the internalTokenId as the serial number
+    ///      This distinction is important for off-chain parsing of TokenUnvaulted events
     function burnRouter(address _nftAddress, uint256 tokenId, bool shouldUnvault)
         internal
         returns (bool success, uint256 serialNumber, bytes memory data)

--- a/src/facets/EmblemVaultUnvaultFacet.sol
+++ b/src/facets/EmblemVaultUnvaultFacet.sol
@@ -359,39 +359,25 @@ contract EmblemVaultUnvaultFacet {
                 LibEmblemVaultStorage.setUnvaulted(_nftAddress, serialNumber, msg.sender);
             }
             data = "";
-        } else {
-            if (LibInterfaceIds.isERC721A(_nftAddress)) {
-                IERC721AVault token = IERC721AVault(_nftAddress);
-                uint256 internalTokenId = token.getInternalTokenId(tokenId);
+        } else if (LibInterfaceIds.isERC721A(_nftAddress)) {
+            IERC721AVault token = IERC721AVault(_nftAddress);
+            uint256 internalTokenId = token.getInternalTokenId(tokenId);
 
-                if (LibEmblemVaultStorage.isUnvaulted(_nftAddress, internalTokenId)) {
-                    revert LibErrors.AlreadyUnvaulted(_nftAddress, internalTokenId);
-                }
-                if (token.ownerOf(internalTokenId) != msg.sender) {
-                    revert LibErrors.NotVaultOwner(_nftAddress, internalTokenId, msg.sender);
-                }
-
-                token.burn(internalTokenId);
-                if (shouldUnvault) {
-                    LibEmblemVaultStorage.setUnvaulted(_nftAddress, internalTokenId, msg.sender);
-                }
-                data = "";
-                serialNumber = internalTokenId;
-            } else {
-                if (LibEmblemVaultStorage.isUnvaulted(_nftAddress, tokenId)) {
-                    revert LibErrors.AlreadyUnvaulted(_nftAddress, tokenId);
-                }
-                IERC721 token = IERC721(_nftAddress);
-                if (token.ownerOf(tokenId) != msg.sender) {
-                    revert LibErrors.NotVaultOwner(_nftAddress, tokenId, msg.sender);
-                }
-                token.burn(tokenId);
-                if (shouldUnvault) {
-                    LibEmblemVaultStorage.setUnvaulted(_nftAddress, tokenId, msg.sender);
-                }
-                serialNumber = tokenId;
-                data = "";
+            if (LibEmblemVaultStorage.isUnvaulted(_nftAddress, internalTokenId)) {
+                revert LibErrors.AlreadyUnvaulted(_nftAddress, internalTokenId);
             }
+            if (token.ownerOf(internalTokenId) != msg.sender) {
+                revert LibErrors.NotVaultOwner(_nftAddress, internalTokenId, msg.sender);
+            }
+
+            token.burn(internalTokenId);
+            if (shouldUnvault) {
+                LibEmblemVaultStorage.setUnvaulted(_nftAddress, internalTokenId, msg.sender);
+            }
+            data = "";
+            serialNumber = internalTokenId;
+        } else {
+            return (false, 0, "");
         }
         return (true, serialNumber, data);
     }

--- a/src/implementations/ERC1155VaultImplementation.sol
+++ b/src/implementations/ERC1155VaultImplementation.sol
@@ -393,21 +393,13 @@ contract ERC1155VaultImplementation is
     }
 
     /**
-     * @notice Retrieves a specific serial number from the owner's array.
-     * @dev    Reverts if the serial number is zero.
-     * @param tokenId The token ID that owns the serial.
-     * @param index The index of the serial within that token ID's serial mapping.
-     * @return The serial number found at the given index.
-     *
-     * Reverts:
-     * - `InvalidSerialNumber()` if the serial at that index is zero.
+     * @notice Retrieves all serial numbers owned by an address for a given token ID.
+     * @param owner The address whose serials to retrieve.
+     * @param tokenId The token ID to get serials for.
+     * @return An array of serial numbers owned by the address for the token ID.
      */
-    function getSerial(uint256 tokenId, uint256 index) external view returns (uint256) {
-        uint256[] storage serials = _ownerTokenSerials[msg.sender][tokenId];
-        if (index >= serials.length) revert InvalidSerialNumber();
-        uint256 serial = serials[index];
-        if (serial == 0) revert InvalidSerialNumber();
-        return serial;
+    function getSerials(address owner, uint256 tokenId) external view returns (uint256[] memory) {
+        return _ownerTokenSerials[owner][tokenId];
     }
 
     /**

--- a/src/implementations/ERC1155VaultImplementation.sol
+++ b/src/implementations/ERC1155VaultImplementation.sol
@@ -428,9 +428,7 @@ contract ERC1155VaultImplementation is
      * @return The address that currently owns the given serial number.
      */
     function getOwnerOfSerial(uint256 serialNumber) external view returns (address) {
-        address owner = _serialOwners[serialNumber];
-        if (owner == address(0)) revert SerialNumberBurned();
-        return owner;
+        return _serialOwners[serialNumber];
     }
 
     /**

--- a/src/implementations/ERC1155VaultImplementation.sol
+++ b/src/implementations/ERC1155VaultImplementation.sol
@@ -62,6 +62,10 @@ contract ERC1155VaultImplementation is
     /// @notice The address of the diamond contract (must pass `onlyDiamond` checks).
     address private _diamondAddress;
 
+    /// @notice The EIP-1967 beacon storage slot
+    bytes32 private constant BEACON_SLOT =
+        0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50;
+
     /// @dev Modifier restricting calls to only the diamond address.
     modifier onlyDiamond() {
         if (msg.sender != _diamondAddress) {
@@ -509,11 +513,9 @@ contract ERC1155VaultImplementation is
      * @return beaconAddress The address stored in the beacon slot.
      */
     function beacon() external view returns (address) {
-        // EIP-1967 beacon slot
-        bytes32 slot = 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50;
         address beaconAddress;
         assembly {
-            beaconAddress := sload(slot)
+            beaconAddress := sload(BEACON_SLOT)
         }
         return beaconAddress;
     }

--- a/src/implementations/ERC1155VaultImplementation.sol
+++ b/src/implementations/ERC1155VaultImplementation.sol
@@ -54,8 +54,6 @@ contract ERC1155VaultImplementation is
     error InvalidIndex();
     /// @notice Thrown when a function that must be called by the diamond is called by a non-diamond address.
     error NotDiamond();
-    /// @notice Thrown when a serial number has been burned or does not exist.
-    error SerialNumberBurned();
 
     // ------------------------------------------------------------------------
     // Storage

--- a/src/interfaces/IIsSerialized.sol
+++ b/src/interfaces/IIsSerialized.sol
@@ -9,11 +9,11 @@ interface IIsSerialized {
     /// @return True if the contract supports serialization
     function isSerialized() external view returns (bool);
 
-    /// @notice Get the serial number for a token at a specific index
+    /// @notice Get all serial numbers owned by an address for a given token ID
+    /// @param owner The address whose serials to retrieve
     /// @param tokenId The ID of the token
-    /// @param index The index of the serial number to retrieve
-    /// @return The serial number at the specified index
-    function getSerial(uint256 tokenId, uint256 index) external view returns (uint256);
+    /// @return An array of serial numbers owned by the address for the token ID
+    function getSerials(address owner, uint256 tokenId) external view returns (uint256[] memory);
 
     /// @notice Get the first serial number owned by an address for a specific token ID
     /// @param owner The address of the owner

--- a/src/libraries/LibDiamond.sol
+++ b/src/libraries/LibDiamond.sol
@@ -114,8 +114,8 @@ library LibDiamond {
 
             // Update selector cache
             ds.facetSelectors[_facetAddress].push(selector);
-            ds.totalSelectors++;
         }
+        ds.totalSelectors += uint96(_functionSelectors.length);
     }
 
     function replaceFunctions(address _facetAddress, bytes4[] memory _functionSelectors) internal {
@@ -194,8 +194,8 @@ library LibDiamond {
             }
             facetSelectorCache.pop();
             delete ds.selectorToFacet[selector];
-            ds.totalSelectors--;
         }
+        ds.totalSelectors -= uint96(_functionSelectors.length);
     }
 
     function initializeDiamondCut(address _init, bytes memory _calldata) internal {

--- a/src/libraries/LibEmblemVaultStorage.sol
+++ b/src/libraries/LibEmblemVaultStorage.sol
@@ -228,19 +228,4 @@ library LibEmblemVaultStorage {
     function isBurnAddress(address addr) internal view returns (bool) {
         return vaultStorage().burnAddresses[addr];
     }
-
-    function initializeVaultStorage() internal {
-        VaultStorage storage vs = vaultStorage();
-        if (vs.initialized) revert AlreadyInitialized();
-
-        vs.metadataBaseUri = "https://v2.emblemvault.io/meta/";
-        vs.unvaultingEnabled = true;
-        vs.INTERFACE_ID_ERC1155 = 0xd9b67a26;
-        vs.INTERFACE_ID_ERC20 = 0x74a1476f;
-        vs.INTERFACE_ID_ERC721A = 0xf4a95f26;
-        vs.recipientAddress = msg.sender;
-        vs.vaultFactory = msg.sender;
-        vs.witnessCount = 0;
-        vs.initialized = true;
-    }
 }

--- a/src/libraries/LibErrors.sol
+++ b/src/libraries/LibErrors.sol
@@ -141,6 +141,9 @@ library LibErrors {
     /// @notice Number of serial numbers does not match amount
     error InvalidSerialNumbersCount();
 
+    /// @notice Required interface is not supported
+    error InterfaceNotSupported(address contractAddress, string interfaceName);
+
     // ============ Initialization Errors ============
 
     /// @notice Already initialized
@@ -254,5 +257,14 @@ library LibErrors {
     /// @notice Check if recipient matches sender
     function revertIfInvalidRecipient(address recipient, address sender) internal pure {
         if (recipient != sender) revert InvalidRecipient();
+    }
+
+    /// @notice Check if contract supports required interface
+    function revertIfInterfaceNotSupported(
+        address contractAddress,
+        bool isSupported,
+        string memory interfaceName
+    ) internal pure {
+        if (!isSupported) revert InterfaceNotSupported(contractAddress, interfaceName);
     }
 }

--- a/src/libraries/LibInterfaceIds.sol
+++ b/src/libraries/LibInterfaceIds.sol
@@ -12,7 +12,7 @@ library LibInterfaceIds {
     bytes4 constant INTERFACE_ID_ERC165 = 0x01ffc9a7;
     bytes4 constant INTERFACE_ID_ERC721A = 0xf4a95f26;
     bytes4 constant INTERFACE_ID_ERC1155 = 0xd9b67a26;
-    bytes4 constant INTERFACE_ID_SERIALIZED = 0x6979ab46;
+    bytes4 constant INTERFACE_ID_SERIALIZED = 0x5d837754; // type(IIsSerialized).interfaceId
 
     // Diamond Interface IDs
     bytes4 constant INTERFACE_ID_DIAMOND_CUT = 0x1f931c1c;

--- a/src/libraries/LibInterfaceIds.sol
+++ b/src/libraries/LibInterfaceIds.sol
@@ -12,7 +12,7 @@ library LibInterfaceIds {
     bytes4 constant INTERFACE_ID_ERC165 = 0x01ffc9a7;
     bytes4 constant INTERFACE_ID_ERC721A = 0xf4a95f26;
     bytes4 constant INTERFACE_ID_ERC1155 = 0xd9b67a26;
-    bytes4 constant INTERFACE_ID_SERIALIZED = type(IIsSerialized).interfaceId;
+    bytes4 constant INTERFACE_ID_SERIALIZED = 0x6979ab46;
 
     // Diamond Interface IDs
     bytes4 constant INTERFACE_ID_DIAMOND_CUT = 0x1f931c1c;

--- a/src/libraries/LibInterfaceIds.sol
+++ b/src/libraries/LibInterfaceIds.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.19;
 
 import "../interfaces/IERC165.sol";
+import "../interfaces/IIsSerialized.sol";
 
 /// @title LibInterfaceIds
 /// @notice Library for interface ID constants and checks
@@ -11,7 +12,7 @@ library LibInterfaceIds {
     bytes4 constant INTERFACE_ID_ERC165 = 0x01ffc9a7;
     bytes4 constant INTERFACE_ID_ERC721A = 0xf4a95f26;
     bytes4 constant INTERFACE_ID_ERC1155 = 0xd9b67a26;
-    bytes4 constant INTERFACE_ID_SERIALIZED = bytes4(keccak256("IsSerialized"));
+    bytes4 constant INTERFACE_ID_SERIALIZED = type(IIsSerialized).interfaceId;
 
     // Diamond Interface IDs
     bytes4 constant INTERFACE_ID_DIAMOND_CUT = 0x1f931c1c;

--- a/src/libraries/LibSignature.sol
+++ b/src/libraries/LibSignature.sol
@@ -8,6 +8,10 @@ library LibSignature {
     // Custom errors
     error InvalidSignature();
 
+    // Half of secp256k1n (the curve order) - used for signature malleability check
+    uint256 constant SECP256K1_N_DIV_2 =
+        0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
+
     /// @notice Recover signer from a signature
     /// @param hash The hash that was signed
     /// @param signature The signature bytes
@@ -30,6 +34,9 @@ library LibSignature {
         }
 
         if (v != 27 && v != 28) revert InvalidSignature();
+
+        // Ensure s is in the lower half of secp256k1n to prevent signature malleability
+        if (uint256(s) > SECP256K1_N_DIV_2) revert InvalidSignature();
 
         bytes memory prefix = "\x19Ethereum Signed Message:\n32";
         bytes32 prefixedHash = keccak256(abi.encodePacked(prefix, hash));

--- a/test/CalculateInterfaceId.t.sol
+++ b/test/CalculateInterfaceId.t.sol
@@ -10,7 +10,7 @@ contract CalculateInterfaceIdTest is Test {
     function testCalculateInterfaceId() public pure {
         // Calculate individual function selectors
         bytes4 isSerialized = bytes4(keccak256("isSerialized()"));
-        bytes4 getSerial = bytes4(keccak256("getSerial(uint256,uint256)"));
+        bytes4 getSerials = bytes4(keccak256("getSerials(address,uint256)"));
         bytes4 getFirstSerialByOwner = bytes4(keccak256("getFirstSerialByOwner(address,uint256)"));
         bytes4 getOwnerOfSerial = bytes4(keccak256("getOwnerOfSerial(uint256)"));
         bytes4 getSerialByOwnerAtIndex =
@@ -18,7 +18,7 @@ contract CalculateInterfaceIdTest is Test {
         bytes4 getTokenIdForSerialNumber = bytes4(keccak256("getTokenIdForSerialNumber(uint256)"));
 
         // XOR all selectors together
-        bytes4 manualInterfaceId = isSerialized ^ getSerial ^ getFirstSerialByOwner
+        bytes4 manualInterfaceId = isSerialized ^ getSerials ^ getFirstSerialByOwner
             ^ getOwnerOfSerial ^ getSerialByOwnerAtIndex ^ getTokenIdForSerialNumber;
 
         // Get interface ID using type()

--- a/test/CalculateInterfaceId.t.sol
+++ b/test/CalculateInterfaceId.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Test, console} from "forge-std/Test.sol";
+import {IIsSerialized} from "../src/interfaces/IIsSerialized.sol";
+
+contract CalculateInterfaceIdTest is Test {
+    function setUp() public {}
+
+    function testCalculateInterfaceId() public {
+        // Calculate individual function selectors
+        bytes4 isSerialized = bytes4(keccak256("isSerialized()"));
+        bytes4 getSerial = bytes4(keccak256("getSerial(uint256,uint256)"));
+        bytes4 getFirstSerialByOwner = bytes4(keccak256("getFirstSerialByOwner(address,uint256)"));
+        bytes4 getOwnerOfSerial = bytes4(keccak256("getOwnerOfSerial(uint256)"));
+        bytes4 getSerialByOwnerAtIndex =
+            bytes4(keccak256("getSerialByOwnerAtIndex(address,uint256,uint256)"));
+        bytes4 getTokenIdForSerialNumber = bytes4(keccak256("getTokenIdForSerialNumber(uint256)"));
+
+        // XOR all selectors together
+        bytes4 manualInterfaceId = isSerialized ^ getSerial ^ getFirstSerialByOwner
+            ^ getOwnerOfSerial ^ getSerialByOwnerAtIndex ^ getTokenIdForSerialNumber;
+
+        // Get interface ID using type()
+        bytes4 autoInterfaceId = type(IIsSerialized).interfaceId;
+
+        // Log both values
+        console.log("Manual calculation:");
+        console.logBytes4(manualInterfaceId);
+        console.log("type() calculation:");
+        console.logBytes4(autoInterfaceId);
+
+        // Verify they match
+        assertEq(manualInterfaceId, autoInterfaceId, "Interface IDs should match");
+    }
+}

--- a/test/CalculateInterfaceId.t.sol
+++ b/test/CalculateInterfaceId.t.sol
@@ -7,7 +7,7 @@ import {IIsSerialized} from "../src/interfaces/IIsSerialized.sol";
 contract CalculateInterfaceIdTest is Test {
     function setUp() public {}
 
-    function testCalculateInterfaceId() public {
+    function testCalculateInterfaceId() public pure {
         // Calculate individual function selectors
         bytes4 isSerialized = bytes4(keccak256("isSerialized()"));
         bytes4 getSerial = bytes4(keccak256("getSerial(uint256,uint256)"));

--- a/test/ERC1155VaultImplementation.t.sol
+++ b/test/ERC1155VaultImplementation.t.sol
@@ -38,8 +38,7 @@ contract ERC1155VaultImplementationTest is Test {
         // Set up the implementation interface
         implementation = ERC1155VaultImplementation(address(proxy));
 
-        // Set up prank for Diamond calls
-        vm.startPrank(mockDiamond);
+        // No need to initialize again since it's done in the constructor
     }
 
     function testInitialState() public view {
@@ -67,11 +66,15 @@ contract ERC1155VaultImplementationTest is Test {
         serialNumbers[2] = 300;
 
         // Mint with external serials
+        vm.prank(mockDiamond);
         implementation.mintWithSerial(user1, 1, 3, serialNumbers);
 
         // Verify
+        vm.prank(user1);
         assertEq(implementation.getSerial(1, 0), 100);
+        vm.prank(user1);
         assertEq(implementation.getSerial(1, 1), 200);
+        vm.prank(user1);
         assertEq(implementation.getSerial(1, 2), 300);
 
         assertEq(implementation.getOwnerOfSerial(100), user1);
@@ -100,6 +103,7 @@ contract ERC1155VaultImplementationTest is Test {
         serialNumbers[2] = 13;
 
         // Mint 3 tokens with external serials
+        vm.prank(mockDiamond);
         implementation.mintWithSerial(user1, 1, 3, serialNumbers);
 
         // Transfer 2 tokens from user1 to user2
@@ -143,6 +147,7 @@ contract ERC1155VaultImplementationTest is Test {
         serialNumbers[1] = 100; // Duplicate
         serialNumbers[2] = 300;
 
+        vm.prank(mockDiamond);
         vm.expectRevert(abi.encodeWithSignature("SerialNumberAlreadyUsed()"));
         implementation.mintWithSerial(user1, 1, 3, serialNumbers);
     }
@@ -154,6 +159,7 @@ contract ERC1155VaultImplementationTest is Test {
         serialNumbers[1] = 0; // Zero
         serialNumbers[2] = 300;
 
+        vm.prank(mockDiamond);
         vm.expectRevert(abi.encodeWithSignature("InvalidSerialNumber()"));
         implementation.mintWithSerial(user1, 1, 3, serialNumbers);
     }
@@ -164,6 +170,7 @@ contract ERC1155VaultImplementationTest is Test {
         serialNumbers[0] = 100;
         serialNumbers[1] = 200;
 
+        vm.prank(mockDiamond);
         vm.expectRevert(abi.encodeWithSignature("InvalidSerialNumbersCount()"));
         implementation.mintWithSerial(user1, 1, 3, serialNumbers);
     }
@@ -172,6 +179,7 @@ contract ERC1155VaultImplementationTest is Test {
         uint256[] memory serialNumbers = new uint256[](1);
         serialNumbers[0] = 100;
 
+        vm.prank(mockDiamond);
         vm.expectRevert(abi.encodeWithSignature("InvalidAmount()"));
         implementation.mintWithSerial(user1, 1, 0, serialNumbers);
     }
@@ -180,13 +188,16 @@ contract ERC1155VaultImplementationTest is Test {
         // Test single serial number
         uint256[] memory serialNumbers = new uint256[](1);
         serialNumbers[0] = 100;
+        vm.prank(mockDiamond);
         implementation.mintWithSerial(user1, 1, 1, serialNumbers);
+        vm.prank(user1);
         assertEq(implementation.getFirstSerialByOwner(user1, 1), 100);
 
         // Test invalid array length
         uint256[] memory invalidSerials = new uint256[](2);
         invalidSerials[0] = 200;
         invalidSerials[1] = 300;
+        vm.prank(mockDiamond);
         vm.expectRevert(abi.encodeWithSignature("InvalidSerialNumbersCount()"));
         implementation.mintWithSerial(user2, 2, 1, invalidSerials);
     }
@@ -195,10 +206,12 @@ contract ERC1155VaultImplementationTest is Test {
         // ...
         uint256[] memory serialNumbers1 = new uint256[](1);
         serialNumbers1[0] = 100;
+        vm.prank(mockDiamond);
         implementation.mintWithSerial(user1, 1, 1, serialNumbers1);
 
         uint256[] memory serialNumbers2 = new uint256[](1);
         serialNumbers2[0] = 100; // same
+        vm.prank(mockDiamond);
         vm.expectRevert(abi.encodeWithSignature("SerialNumberAlreadyUsed()"));
         implementation.mintWithSerial(user1, 2, 1, serialNumbers2);
     }
@@ -231,10 +244,13 @@ contract ERC1155VaultImplementationTest is Test {
         amounts[1] = 3;
 
         // ...
+        vm.prank(mockDiamond);
         implementation.mintBatch(user1, ids, amounts, serialData);
 
         // Check
+        vm.prank(user1);
         assertEq(implementation.getFirstSerialByOwner(user1, 1), 100);
+        vm.prank(user1);
         assertEq(implementation.getSerialByOwnerAtIndex(user1, 1, 1), 200);
 
         assertEq(implementation.getFirstSerialByOwner(user1, 2), 300);
@@ -271,6 +287,7 @@ contract ERC1155VaultImplementationTest is Test {
         mintAmounts[0] = 3;
         mintAmounts[1] = 2;
 
+        vm.prank(mockDiamond);
         implementation.mintBatch(user1, ids, mintAmounts, allSerials);
 
         // Prepare batch transfer
@@ -308,6 +325,7 @@ contract ERC1155VaultImplementationTest is Test {
         serialNumbers1[0] = 100;
         serialNumbers1[1] = 200;
         serialNumbers1[2] = 300;
+        vm.prank(mockDiamond);
         implementation.mintWithSerial(user1, 1, 3, serialNumbers1);
 
         // Transfer some tokens to user2
@@ -360,6 +378,7 @@ contract ERC1155VaultImplementationTest is Test {
         serials[0][0] = 100;
         serials[0][1] = 200;
 
+        vm.prank(mockDiamond);
         vm.expectRevert(abi.encodeWithSignature("InvalidSerialArraysLength()"));
         implementation.mintBatch(user1, ids, amounts, serials);
 
@@ -371,6 +390,7 @@ contract ERC1155VaultImplementationTest is Test {
         serials[1] = new uint256[](1);
         serials[1][0] = 300;
 
+        vm.prank(mockDiamond);
         vm.expectRevert(abi.encodeWithSignature("InvalidSerialNumbersCount()"));
         implementation.mintBatch(user1, ids, amounts, serials);
     }
@@ -396,6 +416,7 @@ contract ERC1155VaultImplementationTest is Test {
         serialData1[0] = serialNumbers1;
         serialData1[1] = serialNumbers2;
 
+        vm.prank(mockDiamond);
         implementation.mintBatch(user1, ids1, amounts1, serialData1);
 
         // Second batch
@@ -420,6 +441,7 @@ contract ERC1155VaultImplementationTest is Test {
         serialData2[0] = serialNumbers3;
         serialData2[1] = serialNumbers4;
 
+        vm.prank(mockDiamond);
         implementation.mintBatch(user1, ids2, amounts2, serialData2);
 
         // Check balances
@@ -450,9 +472,11 @@ contract ERC1155VaultImplementationTest is Test {
         uint256[] memory serialNumbers = new uint256[](1);
         serialNumbers[0] = 999;
 
+        vm.prank(mockDiamond);
         implementation.mintWithSerial(user1, 1, 1, serialNumbers);
 
         // Try to get non-existent index
+        vm.prank(user1);
         vm.expectRevert(abi.encodeWithSignature("InvalidSerialNumber()"));
         implementation.getSerial(1, 1); // we only minted index=0
 

--- a/test/ERC1155VaultImplementation.t.sol
+++ b/test/ERC1155VaultImplementation.t.sol
@@ -70,12 +70,11 @@ contract ERC1155VaultImplementationTest is Test {
         implementation.mintWithSerial(user1, 1, 3, serialNumbers);
 
         // Verify
-        vm.prank(user1);
-        assertEq(implementation.getSerial(1, 0), 100);
-        vm.prank(user1);
-        assertEq(implementation.getSerial(1, 1), 200);
-        vm.prank(user1);
-        assertEq(implementation.getSerial(1, 2), 300);
+        uint256[] memory serials = implementation.getSerials(user1, 1);
+        assertEq(serials.length, 3);
+        assertEq(serials[0], 100);
+        assertEq(serials[1], 200);
+        assertEq(serials[2], 300);
 
         assertEq(implementation.getOwnerOfSerial(100), user1);
         assertEq(implementation.getOwnerOfSerial(200), user1);
@@ -475,14 +474,9 @@ contract ERC1155VaultImplementationTest is Test {
         vm.prank(mockDiamond);
         implementation.mintWithSerial(user1, 1, 1, serialNumbers);
 
-        // Try to get non-existent index
-        vm.prank(user1);
-        vm.expectRevert(abi.encodeWithSignature("InvalidSerialNumber()"));
-        implementation.getSerial(1, 1); // we only minted index=0
-
-        // Try to get tokenId=2
-        vm.expectRevert(abi.encodeWithSignature("InvalidSerialNumber()"));
-        implementation.getSerial(2, 0);
+        // Try to get non-existent token's serials
+        uint256[] memory noSerials = implementation.getSerials(user1, 2);
+        assertEq(noSerials.length, 0);
 
         // Try to get first serial for tokenId=2
         vm.expectRevert(abi.encodeWithSignature("NoSerialsFound()"));

--- a/test/MintPaymentValidation.t.sol
+++ b/test/MintPaymentValidation.t.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "./DiamondVault.t.sol";
+
+contract MintPaymentValidationTest is DiamondVaultTest {
+    function testCannotOverpayForSingleMint() public {
+        // Create signature for minting
+        uint256[] memory serialNumbers = new uint256[](0);
+        bytes memory signature = createSignature(
+            nftCollection,
+            address(0), // ETH payment
+            1 ether,
+            user1,
+            2, // tokenId
+            2, // nonce
+            1, // amount
+            witnessPrivateKey,
+            serialNumbers
+        );
+
+        // Try to mint with more ETH than required
+        vm.startPrank(user1);
+        vm.expectRevert(
+            abi.encodeWithSelector(LibErrors.IncorrectPayment.selector, 2 ether, 1 ether)
+        );
+        EmblemVaultMintFacet(address(diamond)).buyWithSignedPrice{value: 2 ether}(
+            nftCollection, address(0), 1 ether, user1, 2, 2, signature, serialNumbers, 1
+        );
+        vm.stopPrank();
+    }
+
+    function testCannotOverpayForBatchMint() public {
+        // Setup batch parameters
+        uint256[] memory prices = new uint256[](2);
+        prices[0] = 1 ether;
+        prices[1] = 1 ether;
+
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 2;
+        tokenIds[1] = 3;
+
+        uint256[] memory nonces = new uint256[](2);
+        nonces[0] = 2;
+        nonces[1] = 3;
+
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1;
+        amounts[1] = 1;
+
+        bytes[] memory signatures = new bytes[](2);
+        uint256[][] memory serialNumbers = new uint256[][](2);
+        serialNumbers[0] = new uint256[](0);
+        serialNumbers[1] = new uint256[](0);
+
+        // Create signatures for each token
+        for (uint256 i = 0; i < 2; i++) {
+            signatures[i] = createSignature(
+                nftCollection,
+                address(0),
+                prices[i],
+                user1,
+                tokenIds[i],
+                nonces[i],
+                amounts[i],
+                witnessPrivateKey,
+                serialNumbers[i]
+            );
+        }
+
+        // Create batch params
+        EmblemVaultMintFacet.BatchBuyParams memory params = EmblemVaultMintFacet.BatchBuyParams({
+            nftAddress: nftCollection,
+            payment: address(0),
+            prices: prices,
+            to: user1,
+            tokenIds: tokenIds,
+            nonces: nonces,
+            signatures: signatures,
+            serialNumbers: serialNumbers,
+            amounts: amounts
+        });
+
+        // Try to mint with more ETH than required (total price is 2 ether)
+        vm.startPrank(user1);
+        vm.expectRevert(
+            abi.encodeWithSelector(LibErrors.IncorrectPayment.selector, 3 ether, 2 ether)
+        );
+        EmblemVaultMintFacet(address(diamond)).batchBuyWithSignedPrice{value: 3 ether}(params);
+        vm.stopPrank();
+    }
+
+    function testExactPaymentSucceedsForSingleMint() public {
+        // Create signature for minting
+        uint256[] memory serialNumbers = new uint256[](0);
+        bytes memory signature = createSignature(
+            nftCollection,
+            address(0), // ETH payment
+            1 ether,
+            user1,
+            2, // tokenId
+            2, // nonce
+            1, // amount
+            witnessPrivateKey,
+            serialNumbers
+        );
+
+        // Mint with exact ETH amount
+        vm.startPrank(user1);
+        EmblemVaultMintFacet(address(diamond)).buyWithSignedPrice{value: 1 ether}(
+            nftCollection, address(0), 1 ether, user1, 2, 2, signature, serialNumbers, 1
+        );
+        vm.stopPrank();
+
+        // Verify the mint was successful by checking ownership
+        assertEq(IERC721AVault(nftCollection).ownerOf(2), user1);
+    }
+
+    function testExactPaymentSucceedsForBatchMint() public {
+        // Setup batch parameters
+        uint256[] memory prices = new uint256[](2);
+        prices[0] = 1 ether;
+        prices[1] = 1 ether;
+
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 3;
+        tokenIds[1] = 4;
+
+        uint256[] memory nonces = new uint256[](2);
+        nonces[0] = 3;
+        nonces[1] = 4;
+
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1;
+        amounts[1] = 1;
+
+        bytes[] memory signatures = new bytes[](2);
+        uint256[][] memory serialNumbers = new uint256[][](2);
+        serialNumbers[0] = new uint256[](0);
+        serialNumbers[1] = new uint256[](0);
+
+        // Create signatures for each token
+        for (uint256 i = 0; i < 2; i++) {
+            signatures[i] = createSignature(
+                nftCollection,
+                address(0),
+                prices[i],
+                user1,
+                tokenIds[i],
+                nonces[i],
+                amounts[i],
+                witnessPrivateKey,
+                serialNumbers[i]
+            );
+        }
+
+        // Create batch params
+        EmblemVaultMintFacet.BatchBuyParams memory params = EmblemVaultMintFacet.BatchBuyParams({
+            nftAddress: nftCollection,
+            payment: address(0),
+            prices: prices,
+            to: user1,
+            tokenIds: tokenIds,
+            nonces: nonces,
+            signatures: signatures,
+            serialNumbers: serialNumbers,
+            amounts: amounts
+        });
+
+        // Mint with exact ETH amount
+        vm.startPrank(user1);
+        EmblemVaultMintFacet(address(diamond)).batchBuyWithSignedPrice{value: 2 ether}(params);
+        vm.stopPrank();
+
+        // Verify the mints were successful by checking ownership
+        assertEq(IERC721AVault(nftCollection).ownerOf(2), user1);
+        assertEq(IERC721AVault(nftCollection).ownerOf(3), user1);
+    }
+}

--- a/test/SerialNumberOverwrite.t.sol
+++ b/test/SerialNumberOverwrite.t.sol
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "./DiamondVault.t.sol";
+
+contract SerialNumberOverwriteTest is DiamondVaultTest {
+    address erc1155Collection;
+
+    function setUp() public override {
+        // Call parent setUp
+        super.setUp();
+
+        // Create an ERC1155 collection through Diamond
+        vm.prank(address(diamond));
+        erc1155Collection = factory.createERC1155Collection("https://api.test.com/");
+
+        // Enable unvaulting
+        vm.prank(owner);
+        EmblemVaultUnvaultFacet(address(diamond)).setUnvaultingEnabled(true);
+    }
+
+    function testSerialNumberOverwriteScenario() public {
+        // Prepare serial numbers for User1
+        uint256[] memory serials1 = new uint256[](2);
+        serials1[0] = 100;
+        serials1[1] = 200;
+
+        // Create signature for User1's mint
+        bytes memory sig1 = createSignature(
+            erc1155Collection,
+            address(0), // ETH payment
+            0.1 ether,
+            user1,
+            1, // tokenId
+            3, // nonce
+            2, // amount
+            witnessPrivateKey,
+            serials1
+        );
+
+        // User1 mints tokenId=1 with serials [100,200]
+        vm.prank(user1);
+        EmblemVaultMintFacet(address(diamond)).buyWithSignedPrice{value: 0.1 ether}(
+            erc1155Collection,
+            address(0),
+            0.1 ether,
+            user1,
+            1, // tokenId
+            3, // nonce
+            sig1,
+            serials1,
+            2 // amount
+        );
+
+        // Verify User1's initial state
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getSerialByOwnerAtIndex(user1, 1, 0),
+            100,
+            "First serial should be 100"
+        );
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getSerialByOwnerAtIndex(user1, 1, 1),
+            200,
+            "Second serial should be 200"
+        );
+
+        // Prepare serial numbers for User2
+        uint256[] memory serials2 = new uint256[](2);
+        serials2[0] = 300;
+        serials2[1] = 400;
+
+        // Create signature for User2's mint
+        bytes memory sig2 = createSignature(
+            erc1155Collection,
+            address(0), // ETH payment
+            0.1 ether,
+            user2,
+            1, // same tokenId
+            4, // nonce
+            2, // amount
+            witnessPrivateKey,
+            serials2
+        );
+
+        // User2 mints same tokenId=1 with different serials [300,400]
+        vm.prank(user2);
+        EmblemVaultMintFacet(address(diamond)).buyWithSignedPrice{value: 0.1 ether}(
+            erc1155Collection,
+            address(0),
+            0.1 ether,
+            user2,
+            1, // tokenId
+            4, // nonce
+            sig2,
+            serials2,
+            2 // amount
+        );
+
+        // Verify User1's serials are still intact
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getSerialByOwnerAtIndex(user1, 1, 0),
+            100,
+            "User1's first serial should still be 100"
+        );
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getSerialByOwnerAtIndex(user1, 1, 1),
+            200,
+            "User1's second serial should still be 200"
+        );
+
+        // Verify User2's serials are properly stored
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getSerialByOwnerAtIndex(user2, 1, 0),
+            300,
+            "User2's first serial should be at index 0"
+        );
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getSerialByOwnerAtIndex(user2, 1, 1),
+            400,
+            "User2's second serial should be at index 1"
+        );
+
+        // Verify ownership through the implementation
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getOwnerOfSerial(100),
+            user1,
+            "User1 should own 100"
+        );
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getOwnerOfSerial(200),
+            user1,
+            "User1 should own 200"
+        );
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getOwnerOfSerial(300),
+            user2,
+            "User2 should own 300"
+        );
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getOwnerOfSerial(400),
+            user2,
+            "User2 should own 400"
+        );
+    }
+
+    function testBurnAndRemintScenario() public {
+        // First mint to User1
+        uint256[] memory serials1 = new uint256[](2);
+        serials1[0] = 100;
+        serials1[1] = 200;
+
+        bytes memory sig1 = createSignature(
+            erc1155Collection, address(0), 0.1 ether, user1, 1, 3, 2, witnessPrivateKey, serials1
+        );
+
+        vm.prank(user1);
+        EmblemVaultMintFacet(address(diamond)).buyWithSignedPrice{value: 0.1 ether}(
+            erc1155Collection, address(0), 0.1 ether, user1, 1, 3, sig1, serials1, 2
+        );
+
+        // User1 approves diamond for unvaulting
+        vm.prank(user1);
+        ERC1155VaultImplementation(erc1155Collection).setApprovalForAll(address(diamond), true);
+
+        // User1 unvaults one token
+        vm.prank(user1);
+        EmblemVaultUnvaultFacet(address(diamond)).unvault(erc1155Collection, 1);
+
+        // Verify first serial is still owned but second is unvaulted (LIFO)
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getOwnerOfSerial(100),
+            user1,
+            "User1 should still own serial 100"
+        );
+
+        // Check that serial 200 is unvaulted
+        assertTrue(
+            EmblemVaultUnvaultFacet(address(diamond)).isTokenUnvaulted(erc1155Collection, 200),
+            "Serial 200 should be unvaulted"
+        );
+        assertEq(
+            EmblemVaultUnvaultFacet(address(diamond)).getTokenUnvaulter(erc1155Collection, 200),
+            user1,
+            "User1 should be the unvaulter of serial 200"
+        );
+
+        // User1 unvaults second token
+        vm.prank(user1);
+        EmblemVaultUnvaultFacet(address(diamond)).unvault(erc1155Collection, 1);
+
+        // Verify both serials are unvaulted
+        assertTrue(
+            EmblemVaultUnvaultFacet(address(diamond)).isTokenUnvaulted(erc1155Collection, 100),
+            "Serial 100 should be unvaulted"
+        );
+        assertTrue(
+            EmblemVaultUnvaultFacet(address(diamond)).isTokenUnvaulted(erc1155Collection, 200),
+            "Serial 200 should be unvaulted"
+        );
+        assertEq(
+            EmblemVaultUnvaultFacet(address(diamond)).getTokenUnvaulter(erc1155Collection, 100),
+            user1,
+            "User1 should be the unvaulter of serial 100"
+        );
+        assertEq(
+            EmblemVaultUnvaultFacet(address(diamond)).getTokenUnvaulter(erc1155Collection, 200),
+            user1,
+            "User1 should be the unvaulter of serial 200"
+        );
+
+        // User2 mints same tokenId
+        uint256[] memory serials2 = new uint256[](2);
+        serials2[0] = 300;
+        serials2[1] = 400;
+
+        bytes memory sig2 = createSignature(
+            erc1155Collection, address(0), 0.1 ether, user2, 1, 4, 2, witnessPrivateKey, serials2
+        );
+
+        vm.prank(user2);
+        EmblemVaultMintFacet(address(diamond)).buyWithSignedPrice{value: 0.1 ether}(
+            erc1155Collection, address(0), 0.1 ether, user2, 1, 4, sig2, serials2, 2
+        );
+
+        // Verify new serials are properly stored
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getOwnerOfSerial(300),
+            user2,
+            "User2 should own 300"
+        );
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).getOwnerOfSerial(400),
+            user2,
+            "User2 should own 400"
+        );
+    }
+
+    function testTransferScenario() public {
+        // First mint to User1
+        uint256[] memory serials1 = new uint256[](2);
+        serials1[0] = 100;
+        serials1[1] = 200;
+
+        bytes memory sig1 = createSignature(
+            erc1155Collection, address(0), 0.1 ether, user1, 1, 3, 2, witnessPrivateKey, serials1
+        );
+
+        vm.prank(user1);
+        EmblemVaultMintFacet(address(diamond)).buyWithSignedPrice{value: 0.1 ether}(
+            erc1155Collection, address(0), 0.1 ether, user1, 1, 3, sig1, serials1, 2
+        );
+
+        // User1 transfers one token to User2
+        vm.prank(user1);
+        ERC1155VaultImplementation(erc1155Collection).safeTransferFrom(user1, user2, 1, 1, "");
+
+        // User2 mints additional tokens of same ID
+        uint256[] memory serials2 = new uint256[](2);
+        serials2[0] = 300;
+        serials2[1] = 400;
+
+        bytes memory sig2 = createSignature(
+            erc1155Collection, address(0), 0.1 ether, user2, 1, 4, 2, witnessPrivateKey, serials2
+        );
+
+        vm.prank(user2);
+        EmblemVaultMintFacet(address(diamond)).buyWithSignedPrice{value: 0.1 ether}(
+            erc1155Collection, address(0), 0.1 ether, user2, 1, 4, sig2, serials2, 2
+        );
+
+        // Verify balances
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).balanceOf(user1, 1),
+            1,
+            "User1 should have 1 token"
+        );
+        assertEq(
+            ERC1155VaultImplementation(erc1155Collection).balanceOf(user2, 1),
+            3,
+            "User2 should have 3 tokens"
+        );
+
+        // Verify serial ownership after transfer and new mint
+        uint256 user1Serial =
+            ERC1155VaultImplementation(erc1155Collection).getFirstSerialByOwner(user1, 1);
+        assertTrue(
+            user1Serial == 100 || user1Serial == 200,
+            "User1 should still own one of their original serials"
+        );
+
+        // Get all of User2's serials
+        uint256[] memory user2Serials = new uint256[](3);
+        for (uint256 i = 0; i < 3; i++) {
+            user2Serials[i] =
+                ERC1155VaultImplementation(erc1155Collection).getSerialByOwnerAtIndex(user2, 1, i);
+        }
+
+        // Verify User2 has the transferred serial and their new ones
+        bool hasTransferredSerial = false;
+        bool has300 = false;
+        bool has400 = false;
+
+        for (uint256 i = 0; i < 3; i++) {
+            if (user2Serials[i] == 100 || user2Serials[i] == 200) hasTransferredSerial = true;
+            if (user2Serials[i] == 300) has300 = true;
+            if (user2Serials[i] == 400) has400 = true;
+        }
+
+        assertTrue(hasTransferredSerial, "User2 should have one of User1's original serials");
+        assertTrue(has300, "User2 should have serial 300");
+        assertTrue(has400, "User2 should have serial 400");
+    }
+}


### PR DESCRIPTION
- Replace revertIfInsufficientETH with revertIfIncorrectPayment
- Forward exact price amount instead of msg.value
- Add tests for payment validation
- Prevents user fund loss from overpayments

Audit item: 5